### PR TITLE
Allow for fallback scope type

### DIFF
--- a/src/action_library.js
+++ b/src/action_library.js
@@ -4,6 +4,8 @@ const { env } = require('process');
 const yaml = require('yaml');
 
 class action_library {
+  #fallbackScope = 'fallback';
+  
   getFileYaml = path => {
     const fileData = fs.readFileSync(path, 'utf8');
     const fileYaml = yaml.parse(fileData);
@@ -30,7 +32,7 @@ class action_library {
       .split('@')[1]
       .split(' ')
       .map(s => s.toUpperCase());
-    return scopes.includes(scope.toUpperCase());
+    return scopes.includes(scope.toUpperCase()) || scopes.includes(this#.fallbackScope.toUpperCase());
   };
 
   buildAllKeysUsed = newItems =>


### PR DESCRIPTION
# Summary of PR changes
#10 

This PR does not implement the issue 100%.  Rather just introduces a static scope value that can be used.

Another way to mimic this behavior without modifying this action would be to run this action twice.  One with the `fallback` scope value, then again with the environment scope you are wanting.

## PR Requirements
- [ ] For JavaScript actions, the action has been recompiled.  
  - See the *Recompiling* section of the repository's README.md for more details.
  - This does not apply to Composite Run Steps actions unless a package.json is present and contains a build script.
- [ ] For major, minor, or breaking changes, at least one of the commit messages contains the appropriate `+semver:` keywords.
  - See the *Incrementing the Version* section of the repository's README.md for more details.
- [ ] The examples in the repository's `README.md` have been updated with the new version.  
  - See the *Incrementing the Version* section of the repository's README.md for more details on how the version will be incremented.
- [x] The action code does not contain sensitive information.
